### PR TITLE
Fix for broken unicorn config

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,7 +1,14 @@
 # Config file for Unicorn application server
 #
 # set path to application
-app_dir = File.expand_path("../..", __FILE__)
+if ENV["RAILS_ENV"] == "production"
+  app_dir = "/srv/www/app.paysymmetry.com/current"
+else
+  app_dir = File.expand_path("../..", __FILE__)
+end
+
+puts "app_dir is #{app_dir}"
+
 shared_dir = "#{app_dir}/shared"
 working_directory app_dir
 


### PR DESCRIPTION
App server was restarting in the old release directory after a deploy. They were doing this because `app_dir` was being set to the release folder and not the `current` symlink.
